### PR TITLE
Add prometheus to aspnetcore startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN dotnet publish aspnetapp/aspnetapp.csproj -c Release -o /app
 
 RUN dotnet test --logger "trx;LogFileName=./aspnetapp.trx"
 
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:3.1-alpine
 
 COPY --from=builder /app .
 

--- a/src/aspnetapp/Controllers/HomeController.cs
+++ b/src/aspnetapp/Controllers/HomeController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using aspnetapp.Services;
+using Microsoft.AspNetCore.Mvc;
 
 namespace aspnetapp.Controllers
 {
@@ -6,6 +7,7 @@ namespace aspnetapp.Controllers
     {
         public IActionResult Index()
         {
+            MetricsManager.HomeControllerHit.Inc();
             return View();
         }
 

--- a/src/aspnetapp/Options/StartupConfiguration.cs
+++ b/src/aspnetapp/Options/StartupConfiguration.cs
@@ -1,0 +1,7 @@
+namespace aspnetapp.Options
+{
+    public class StartupConfiguration
+    {
+        public bool UsePrometheus { get; set; }
+    }
+}

--- a/src/aspnetapp/Program.cs
+++ b/src/aspnetapp/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
 namespace aspnetapp
@@ -16,6 +17,15 @@ namespace aspnetapp
                     logging.AddConsole();
                     logging.AddDebug();
                     logging.AddEventSourceLogger();
+                })
+                .ConfigureAppConfiguration((hostingContext, config) =>
+                {
+                    var env = hostingContext.HostingEnvironment;
+
+                    config.SetBasePath(env.ContentRootPath)
+                        .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                        .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
+                        .AddEnvironmentVariables();
                 })
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseIISIntegration()

--- a/src/aspnetapp/Services/MetricsManager.cs
+++ b/src/aspnetapp/Services/MetricsManager.cs
@@ -1,0 +1,15 @@
+using Prometheus;
+
+namespace aspnetapp.Services
+{
+    public class MetricsManager
+    {
+        public static readonly Counter HomeControllerHit = Metrics
+            .CreateCounter("home_controller_hit", "Number of times the home controller has been hit");
+
+        public static void Publish()
+        {
+            HomeControllerHit.Publish();
+        }
+    }
+}

--- a/src/aspnetapp/Startup.cs
+++ b/src/aspnetapp/Startup.cs
@@ -1,8 +1,11 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using aspnetapp.Options;
+using aspnetapp.Services;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Prometheus;
 
 namespace aspnetapp
 {
@@ -25,11 +28,15 @@ namespace aspnetapp
         {
             // Add framework services.
             services.AddMvc(opts => opts.EnableEndpointRouting = false);
+            
+            services.AddHealthChecks();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+            var startupConfiguration = Configuration.GetSection("StartupConfiguration").Get<StartupConfiguration>();
+            
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
@@ -40,6 +47,11 @@ namespace aspnetapp
                 app.UseExceptionHandler("/Home/Error");
             }
 
+            if (startupConfiguration.UsePrometheus)
+            {
+                MetricsManager.Publish();
+            }
+
             app.UseStaticFiles();
 
             app.UseMvc(routes =>
@@ -47,6 +59,18 @@ namespace aspnetapp
                 routes.MapRoute(
                     name: "default",
                     template: "{controller=Home}/{action=Index}/{id?}");
+            });
+            
+            app.UseRouting();
+            
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+                endpoints.MapHealthChecks("/health");
+                if (startupConfiguration.UsePrometheus)
+                {
+                    endpoints.MapMetrics();   
+                }
             });
         }
     }

--- a/src/aspnetapp/appsettings.Development.json
+++ b/src/aspnetapp/appsettings.Development.json
@@ -6,5 +6,8 @@
       "System": "Information",
       "Microsoft": "Information"
     }
+  },
+  "StartupConfiguration": {
+    "UsePrometheus": false
   }
 }

--- a/src/aspnetapp/appsettings.json
+++ b/src/aspnetapp/appsettings.json
@@ -4,5 +4,8 @@
     "LogLevel": {
       "Default": "Warning"
     }
+  },
+  "StartupConfiguration": {
+    "UsePrometheus": true
   }
 }

--- a/src/aspnetapp/aspnetapp.csproj
+++ b/src/aspnetapp/aspnetapp.csproj
@@ -6,6 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="4.1.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Added /health endpoint
* Added /metrics endpoint

These should quite happily be pulled by prometheus and be present in grafana to build your own graf ;) etc.

This can also be pulled in by values with the new configuration change, if the environment variables
StartupConfiguration__UsePrometheus is set it will use that value over the change in appsettings.json